### PR TITLE
Fix destructure in Clojure 1.10.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-rcon "0.1.0"
+(defproject clj-rcon "0.1.1"
   :description "Source RCON protocol implementation"
   :url "https://github.com/gpittarelli/clj-rcon"
   :license {:name "MIT License"

--- a/src/clj_rcon/codecs.clj
+++ b/src/clj_rcon/codecs.clj
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [clojure.set :refer [map-invert]]))
 
-(defn- write-only-str-length [as-codec & {:keys [offset] :or {:offset 0}}]
+(defn- write-only-str-length [as-codec & {:keys [offset] :or {offset 0}}]
   (reify b/BinaryIO
     ;; For our specific use case: only ever write the header when
     ;; encoding; for reading/decoding, we'll handle the framing at


### PR DESCRIPTION
`:or` expects a map of symbols to values, not keywords to values. This was unintentionally allowed in the past but is no longer valid. See this thread: https://ask.clojure.org/index.php/9643/has-the-destructuring-spec-changed-since-1-8-0